### PR TITLE
A single mistyped character made the link not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Above link contains link to docs, purchasable module, etc.
 
 
 ## Contributing Guidelines
-If you would like to contribute you have to follow the contributing guidelines from [CONTRIBUTING.md](https://github.com/sTyNoOutlet/BanIt/blob/master/CONTRIBUTING.md)
+If you would like to contribute you have to follow the contributing guidelines from [CONTRIBUTING.md](https://github.com/TyNoOutlet/BanIt/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
When I added a link to the CONTRIBUTING.md I mistyped one character and the whole link did not work.